### PR TITLE
Create cache folder if not created

### DIFF
--- a/src/librarycontroller.cpp
+++ b/src/librarycontroller.cpp
@@ -28,7 +28,13 @@ void LibraryController::initialize(Glib::RefPtr<Gtk::ListStore> listStorePtr) {
     this->mListStore = listStorePtr;
 
     std::string dbLibraryPath = deadbeef->get_system_dir(DDB_SYS_DIR_CACHE);
-    this->mLibraryPath = dbLibraryPath + "/media-library/library.bin";
+    dbLibraryPath += "/media-library";
+    
+    if (!std::filesystem::exists(dbLibraryPath)) {
+        std::filesystem::create_directories(dbLibraryPath);
+    }
+
+    this->mLibraryPath = dbLibraryPath + "/library.bin";
 
     pluginLog(2, "Library Controller - Starting maintenance thread");
     this->mMaintenanceThread = new std::thread(&LibraryController::maintenanceThread, this);


### PR DESCRIPTION
Added a simple check in case cache folder doesn't exist, I think most users in case of problems will delete whole folder instead of it's contents, this patch fixes it. Have no clue where or how the media-library cache folder is created, so removing it would be probably a good idea as it's going to be replaced with this.