### PR TITLE
Replace escape tooltip with gtk equivalent

### DIFF
--- a/include/utils.hpp
+++ b/include/utils.hpp
@@ -6,15 +6,6 @@
 class Utils {
 public:
     /**
-     * Replaces & with &amp; as defined by GTK.
-     * 
-     * @param tooltip String to be cleaned.
-     * 
-     * @return Edited string.
-     */
-    static std::string escapeTooltip(std::string tooltip);
-
-    /**
      * Retrieves local theme's gtk icon by it's name in desired resolution.
      * 
      * @param name Gtk icon name, see icons in Glade or documentation

--- a/src/librarycontroller.cpp
+++ b/src/librarycontroller.cpp
@@ -402,7 +402,7 @@ void LibraryController::refreshModel() {
         row[mModelColumns.mColumnTitle] = entry->Name;
         row[mModelColumns.mColumnSubtitle] = entry->Artist;
         row[mModelColumns.mColumnAlbumPointer] = entry;
-        row[mModelColumns.mColumnTooltip] = Utils::escapeTooltip(entry->Name);//+ " - " + entry->Artist;
+        row[mModelColumns.mColumnTooltip] = Glib::Markup::escape_text(entry->Name);
         row[mModelColumns.mColumnVisibility] = true;
     }
 }

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -18,19 +18,6 @@
 #include "plugin.hpp"
 #include "settings.hpp"
 
-std::string Utils::escapeTooltip(std::string tooltip) {
-    uint i = 0;
-    std::string n = tooltip;
-    // Memory leak? See Valgrind
-    for (char const &c : n) {
-        i++;
-        if (c == '&') {
-            n.insert(i, "amp;");
-        }
-    }
-    return n;
-}
-
 Glib::RefPtr<Gdk::Pixbuf> Utils::getIconByName(const char* name, uint size, bool force) {
     Glib::RefPtr<Gtk::IconTheme> theme = Gtk::IconTheme::get_default();
     Gtk::IconInfo icon = theme->lookup_icon(name, size);


### PR DESCRIPTION
Should've done this ages ago, but took me a while to find it in the documentation.