### PR TITLE
Refactor filebrowser

### DIFF
--- a/include/filebrowser.hpp
+++ b/include/filebrowser.hpp
@@ -16,9 +16,9 @@ public:
      * 
      * @return Vector of directory entries for path
      */
-    static std::vector<std::filesystem::directory_entry> getFileList(std::filesystem::path path, bool sort, bool showHiddenFiles);
+    static std::vector<std::filesystem::directory_entry> getFileList(std::filesystem::path path, bool sort, bool showHiddenFiles, bool onlyDirectories = false);
 
-    static std::vector<std::filesystem::path> getDirectoryList(std::filesystem::path path, bool sort, bool showHiddenFiles, bool includeItself);
+    static std::vector<std::filesystem::directory_entry> getDirectoryList(std::filesystem::path path, bool sort, bool showHiddenFiles, bool includeItself);
 
     /**
      * @param directory

--- a/src/filebrowser.cpp
+++ b/src/filebrowser.cpp
@@ -16,9 +16,9 @@
 
 std::unordered_map<std::string, int> Filebrowser::VALID_EXTENSIONS = std::unordered_map<std::string, int>();
 
-std::vector<std::filesystem::directory_entry> Filebrowser::getFileList(std::filesystem::path path, bool sort, bool showHiddenFiles) {
+std::vector<std::filesystem::directory_entry> Filebrowser::getFileList(std::filesystem::path path, bool sort, bool showHiddenFiles, bool onlyDirectories) {
     std::vector<std::filesystem::directory_entry> files = {};
-    std::string entryLowercase;
+
     for(const auto &entry : std::filesystem::directory_iterator(path)) {
         struct stat buffer; 
         // Check permissions and errors
@@ -34,12 +34,17 @@ std::vector<std::filesystem::directory_entry> Filebrowser::getFileList(std::file
         // Add every directory, we can remove them later
         if (entry.is_directory()) {
             files.push_back(entry);
-            continue;
+
+            if (onlyDirectories) {
+                continue;
+            }
         }
 
         // Check file extension
-        if (Filebrowser::VALID_EXTENSIONS.find(entry.path().extension()) != Filebrowser::VALID_EXTENSIONS.end()) {
-            files.push_back(entry);
+        if (!onlyDirectories) {
+            if (Filebrowser::VALID_EXTENSIONS.find(entry.path().extension()) != Filebrowser::VALID_EXTENSIONS.end()) {
+                files.push_back(entry);
+            }
         }
     }
 
@@ -58,42 +63,11 @@ std::vector<std::filesystem::directory_entry> Filebrowser::getFileList(std::file
     return files;
 }
 
-std::vector<std::filesystem::path> Filebrowser::getDirectoryList(std::filesystem::path path, bool sort, bool showHiddenFiles, bool includeItself) {
-    std::vector<std::filesystem::path> directories = {};
-    std::string entryLowercase;
+std::vector<std::filesystem::directory_entry> Filebrowser::getDirectoryList(std::filesystem::path path, bool sort, bool showHiddenFiles, bool includeItself) {
+    std::vector<std::filesystem::directory_entry> directories = Filebrowser::getFileList(path, sort, showHiddenFiles, true);
 
     if (includeItself) {
-        directories.push_back(path);
-    }
-
-    for(const auto &entry : std::filesystem::directory_iterator(path)) {
-        struct stat buffer; 
-        // Check permissions and errors
-        if (stat(entry.path().c_str(), &buffer) != 0 || access(entry.path().c_str(), R_OK)) {
-            continue;
-        }
-
-        // Hidden files
-        if (!showHiddenFiles && entry.path().filename().string()[0] == '.') {
-            continue;
-        }
-
-        // Add every directory, we can remove them later
-        if (entry.is_directory()) {
-            directories.push_back(entry.path());
-        }
-    }
-
-    if (sort) {
-        std::sort(directories.begin(), directories.end(), 
-            [](const std::filesystem::path &s1, const std::filesystem::path &s2) -> bool {
-                //compare date modified
-                struct stat buffer1, buffer2;
-                stat(s1.c_str(), &buffer1);
-                stat(s2.c_str(), &buffer2);
-                return buffer1.st_mtime > buffer2.st_mtime;
-                //return strcasecmp(s1.path().c_str(), s2.path().c_str()) < 0 ? true : false;
-            });
+        directories.push_back(std::filesystem::directory_entry(path));
     }
 
     return directories;

--- a/src/filebrowser.cpp
+++ b/src/filebrowser.cpp
@@ -12,10 +12,6 @@
 #define stat _stat
 #endif
 
-#ifdef _MSC_VER
-#define strcasecmp _stricmp
-#endif
-
 #include <iostream>
 
 std::unordered_map<std::string, int> Filebrowser::VALID_EXTENSIONS = std::unordered_map<std::string, int>();

--- a/src/filebrowser.cpp
+++ b/src/filebrowser.cpp
@@ -1,9 +1,20 @@
 #include "filebrowser.hpp"
 
-#include "string.h"
+#include <string.h>
 #include <algorithm>
 #include <sys/stat.h>
+
+#ifndef WIN32
 #include <unistd.h>
+#endif
+
+#ifdef WIN32
+#define stat _stat
+#endif
+
+#ifdef _MSC_VER
+#define strcasecmp _stricmp
+#endif
 
 #include <iostream>
 
@@ -13,7 +24,6 @@ std::vector<std::filesystem::directory_entry> Filebrowser::getFileList(std::file
     std::vector<std::filesystem::directory_entry> files = {};
     std::string entryLowercase;
     for(const auto &entry : std::filesystem::directory_iterator(path)) {
-        // Replace with non-POSIX?
         struct stat buffer; 
         // Check permissions and errors
         if (stat(entry.path().c_str(), &buffer) != 0 || access(entry.path().c_str(), R_OK)) {
@@ -38,7 +48,6 @@ std::vector<std::filesystem::directory_entry> Filebrowser::getFileList(std::file
     }
 
     if (sort) {
-        // Replace with non-POSIX?
         std::sort(files.begin(), files.end(), 
             [](const std::filesystem::directory_entry &s1, const std::filesystem::directory_entry &s2) -> bool {
                 //compare date modified
@@ -62,7 +71,6 @@ std::vector<std::filesystem::path> Filebrowser::getDirectoryList(std::filesystem
     }
 
     for(const auto &entry : std::filesystem::directory_iterator(path)) {
-        // Replace with non-POSIX?
         struct stat buffer; 
         // Check permissions and errors
         if (stat(entry.path().c_str(), &buffer) != 0 || access(entry.path().c_str(), R_OK)) {
@@ -81,7 +89,6 @@ std::vector<std::filesystem::path> Filebrowser::getDirectoryList(std::filesystem
     }
 
     if (sort) {
-        // Replace with non-POSIX?
         std::sort(directories.begin(), directories.end(), 
             [](const std::filesystem::path &s1, const std::filesystem::path &s2) -> bool {
                 //compare date modified

--- a/src/librarycontroller.cpp
+++ b/src/librarycontroller.cpp
@@ -371,9 +371,9 @@ void LibraryController::updateInotifyFolders() {
         for (auto dirPath : Filebrowser::getDirectoryList(mlPath, false, false, true)) {
             if (this->watchDescriptors.find(dirPath) == this->watchDescriptors.end()) {
                 if (!initial) pluginLog(2, "Inotify Thread - Adding watch for new directory.");
-                int wd = inotify_add_watch(this->fd, dirPath.c_str(), IN_CREATE | IN_DELETE | IN_MODIFY | IN_MOVED_FROM | IN_MOVED_TO);
+                int wd = inotify_add_watch(this->fd, dirPath.path().c_str(), IN_CREATE | IN_DELETE | IN_MODIFY | IN_MOVED_FROM | IN_MOVED_TO);
                 if (wd < 0) {
-                    pluginLog(0, "Inotify Thread - Couldn't add watch for " + dirPath.string());
+                    pluginLog(0, "Inotify Thread - Couldn't add watch for " + dirPath.path().string());
                     continue;
                 }
                 this->watchDescriptors[dirPath] = wd;


### PR DESCRIPTION
First two commits are very simple and only add windows support. The third commit is optional, but I sincerely hate copy pasting code, so this refactor avoids that and replaces it with something more sensible, that keeps the code clean.