### PR TITLE
Refactored metadata readers to work as intended

### DIFF
--- a/include/library/coverimage.hpp
+++ b/include/library/coverimage.hpp
@@ -8,17 +8,13 @@
 
 class CoverImage {
 public:
-    CoverImage(TagLib::ByteVector bytes, int pixBufSize);
     CoverImage(std::filesystem::path path, int pixBufSize);
-    CoverImage(std::vector<char> bytes, int pixBufSize);
     CoverImage();
     ~CoverImage();
 
     void regeneratePixbuf(int pixBufSize);
-    void generatePixbuf(TagLib::ByteVector bytes, int pixBufSize);
 
     std::vector<char> data;
-    int size;
     Glib::RefPtr<Gdk::Pixbuf> CoverPixbuf;
     std::string hash;
 
@@ -26,7 +22,4 @@ public:
     void serialize(Archive &a, const unsigned version){
         a & data & hash;
     }
-
-private:
-    void loadMetaData();
 };

--- a/include/library/mediafile.hpp
+++ b/include/library/mediafile.hpp
@@ -34,7 +34,4 @@ public:
     void serialize(Archive &a, const unsigned version){
         a & Path & Title & Artists & Album & Genre & Year & Length & FileFormat & LastModified & Cover & AlbumID & MetaData;
     }
-
-private:
-    void loadMetaData();
 };

--- a/include/metadata/abstract/id3v2reader.hpp
+++ b/include/metadata/abstract/id3v2reader.hpp
@@ -9,5 +9,4 @@ public:
     virtual ~ID3v2Reader();
 protected:
     Glib::RefPtr<Gdk::Pixbuf> getImageFromTag(TagLib::ID3v2::Tag* tag, int size);
-    TagLib::ByteVector* getDataFromTag(TagLib::ID3v2::Tag* tag);
 };

--- a/include/metadata/implementation/flacreader.hpp
+++ b/include/metadata/implementation/flacreader.hpp
@@ -8,6 +8,5 @@ public:
     ~FlacReader();
 
     Glib::RefPtr<Gdk::Pixbuf> getImage(std::filesystem::path path, int size) override;
-    TagLib::ByteVector* getData(std::filesystem::path path) override;
 private:
 };

--- a/include/metadata/implementation/mp3reader.hpp
+++ b/include/metadata/implementation/mp3reader.hpp
@@ -8,6 +8,5 @@ public:
     ~MP3Reader();
 
     Glib::RefPtr<Gdk::Pixbuf> getImage(std::filesystem::path path, int size);
-    TagLib::ByteVector* getData(std::filesystem::path path);
 private:
 };

--- a/include/metadata/implementation/oggreader.hpp
+++ b/include/metadata/implementation/oggreader.hpp
@@ -8,6 +8,5 @@ public:
     ~OggReader();
 
     Glib::RefPtr<Gdk::Pixbuf> getImage(std::filesystem::path path, int size);
-    TagLib::ByteVector* getData(std::filesystem::path path);
 private:
 };

--- a/include/metadata/implementation/wavreader.hpp
+++ b/include/metadata/implementation/wavreader.hpp
@@ -8,6 +8,5 @@ public:
     ~WavReader();
 
     Glib::RefPtr<Gdk::Pixbuf> getImage(std::filesystem::path path, int size);
-    TagLib::ByteVector* getData(std::filesystem::path path);
 private:
 };

--- a/include/metadata/reader.hpp
+++ b/include/metadata/reader.hpp
@@ -10,7 +10,6 @@ public:
     virtual ~Reader();
 
     virtual Glib::RefPtr<Gdk::Pixbuf> getImage(std::filesystem::path path, int size) = 0;
-    virtual TagLib::ByteVector* getData(std::filesystem::path path) = 0;
 protected:
     Glib::RefPtr<Gdk::Pixbuf> getImageFromData(TagLib::ByteVector bytes, int size);
 };

--- a/include/metadata/readerfactory.hpp
+++ b/include/metadata/readerfactory.hpp
@@ -19,8 +19,7 @@ public:
      * 
      * @return Pointer to the image.
      */
-    static Glib::RefPtr<Gdk::Pixbuf> getImage(std::filesystem::path path, int size, bool* shouldCache);
-    static TagLib::ByteVector* getImageData(std::filesystem::path path);
+    static Glib::RefPtr<Gdk::Pixbuf> getImage(std::filesystem::path path, int size);
 private:
     ReaderFactory();
     ~ReaderFactory();

--- a/src/library/mediafile.cpp
+++ b/src/library/mediafile.cpp
@@ -8,6 +8,8 @@
 #include "settings.hpp"
 #include "readerfactory.hpp"
 
+MediaFile::MediaFile() { };
+
 MediaFile::MediaFile(std::filesystem::path path) {
     TagLib::FileRef f(path.c_str());
 
@@ -60,9 +62,6 @@ MediaFile::MediaFile(std::filesystem::path path) {
         this->LastModified = 0;
     }
     this->Cover = new CoverImage(path, deadbeef->conf_get_int(ML_ICON_SIZE, 32));
-}
-
-MediaFile::MediaFile() {
 }
 
 MediaFile::~MediaFile() {

--- a/src/library/medialibrary.cpp
+++ b/src/library/medialibrary.cpp
@@ -227,7 +227,6 @@ void MediaLibrary::loadCovers() {
     int size = deadbeef->conf_get_int(ML_ICON_SIZE, 128);
     for (auto mediaFile : this->mMediaFiles) {
         mediaFile->Cover->regeneratePixbuf(size);
-
     }
     for (auto album : this->mAlbumMap) {
         album.second->Cover->regeneratePixbuf(size);

--- a/src/metadata/abstract/id3v2reader.cpp
+++ b/src/metadata/abstract/id3v2reader.cpp
@@ -16,19 +16,5 @@ Glib::RefPtr<Gdk::Pixbuf> ID3v2Reader::getImageFromTag(TagLib::ID3v2::Tag* tag, 
     return image;
 }
 
-TagLib::ByteVector* ID3v2Reader::getDataFromTag(TagLib::ID3v2::Tag* tag) {
-    TagLib::ByteVector* data = new TagLib::ByteVector();
-
-    TagLib::ID3v2::FrameList frameList = tag->frameListMap()["APIC"];
-    for(const auto &frame : frameList) {
-        TagLib::ID3v2::AttachedPictureFrame* pictureFrame = static_cast<TagLib::ID3v2::AttachedPictureFrame*>(frame);
-        *data = pictureFrame->picture();
-        if (data->size()) {
-            return data;
-        }
-    }
-    return nullptr;
-}
-
 ID3v2Reader::~ID3v2Reader() {
 }

--- a/src/metadata/implementation/flacreader.cpp
+++ b/src/metadata/implementation/flacreader.cpp
@@ -28,28 +28,5 @@ Glib::RefPtr<Gdk::Pixbuf> FlacReader::getImage(std::filesystem::path path, int s
     return image;
 }
 
-TagLib::ByteVector* FlacReader::getData(std::filesystem::path path) {
-    TagLib::FLAC::File file(path.c_str());
-
-    TagLib::ByteVector* data = nullptr;
-    if (file.isValid()) {
-        if (file.hasID3v2Tag()) {
-            TagLib::ID3v2::Tag* tag = file.ID3v2Tag();
-            data = this->getDataFromTag(tag);
-            if (data) {
-                return data;
-            }
-        }
-        TagLib::ByteVector* newData = new TagLib::ByteVector();
-        for (const auto &picture : file.pictureList()) {
-            *newData = picture->data();
-            if (newData->size()) {
-                return newData;
-            }
-        }
-    }
-    return data;
-}
-
 FlacReader::~FlacReader() {
 }

--- a/src/metadata/implementation/mp3reader.cpp
+++ b/src/metadata/implementation/mp3reader.cpp
@@ -22,21 +22,5 @@ Glib::RefPtr<Gdk::Pixbuf> MP3Reader::getImage(std::filesystem::path path, int si
     return image;
 }
 
-TagLib::ByteVector* MP3Reader::getData(std::filesystem::path path) {
-    TagLib::MPEG::File file(path.c_str());
-
-    TagLib::ByteVector* data = nullptr;
-    if (file.isValid()) {
-        if (file.hasID3v2Tag()) {
-            TagLib::ID3v2::Tag* tag = file.ID3v2Tag();
-            data = this->getDataFromTag(tag);
-            if (data) {
-                return data;
-            }
-        }
-    }
-    return data;
-}
-
 MP3Reader::~MP3Reader() {
 }

--- a/src/metadata/implementation/oggreader.cpp
+++ b/src/metadata/implementation/oggreader.cpp
@@ -26,24 +26,5 @@ Glib::RefPtr<Gdk::Pixbuf> OggReader::getImage(std::filesystem::path path, int si
     return image;
 }
 
-TagLib::ByteVector* OggReader::getData(std::filesystem::path path) {
-    TagLib::Ogg::Vorbis::File file(path.c_str());
-
-    TagLib::ByteVector* data = new TagLib::ByteVector();
-    if (file.isValid()) {
-        if (file.tag()) {
-            TagLib::Ogg::XiphComment* tag = file.tag();
-            TagLib::List<TagLib::FLAC::Picture*> pictureList = tag->pictureList();
-            for (const auto &picture : pictureList) {
-                *data = picture->data();
-                if (data->size()) {
-                    return data;
-                }
-            }
-        }
-    }
-    return nullptr;
-}
-
 OggReader::~OggReader() {
 }

--- a/src/metadata/implementation/wavreader.cpp
+++ b/src/metadata/implementation/wavreader.cpp
@@ -22,21 +22,5 @@ Glib::RefPtr<Gdk::Pixbuf> WavReader::getImage(std::filesystem::path path, int si
     return image;
 }
 
-TagLib::ByteVector* WavReader::getData(std::filesystem::path path) {
-    TagLib::RIFF::WAV::File file(path.c_str());
-
-    TagLib::ByteVector* data = nullptr;
-    if (file.isValid()) {
-        if (file.hasID3v2Tag()) {
-            TagLib::ID3v2::Tag* tag = file.ID3v2Tag();
-            data = this->getDataFromTag(tag);
-            if (data) {
-                return data;
-            }
-        }
-    }
-    return data;
-}
-
 WavReader::~WavReader() {
 }

--- a/src/metadata/readerfactory.cpp
+++ b/src/metadata/readerfactory.cpp
@@ -9,8 +9,7 @@
 
 #include <boost/algorithm/string.hpp>
 
-Glib::RefPtr<Gdk::Pixbuf> ReaderFactory::getImage(std::filesystem::path path, int size, bool* shouldCache) {
-    *shouldCache = false;
+Glib::RefPtr<Gdk::Pixbuf> ReaderFactory::getImage(std::filesystem::path path, int size) {
     if (!path.has_extension()) {
         return Utils::getIconByName("audio-x-generic", size);
     }
@@ -26,30 +25,11 @@ Glib::RefPtr<Gdk::Pixbuf> ReaderFactory::getImage(std::filesystem::path path, in
         delete reader;
 
         if (image.get()) {
-            *shouldCache = true;
             return image;
         }
     }
 
     return Utils::getIconByName("audio-x-generic", size);
-}
-
-TagLib::ByteVector* ReaderFactory::getImageData(std::filesystem::path path) {
-    TagLib::ByteVector* data = nullptr;
-    if (!path.has_extension()) {
-        return data;
-    }
-
-    std::string extension = path.extension();
-    boost::to_lower(extension);
-
-    Reader* reader = ReaderFactory::createReader(extension);
-
-    if (reader) {
-        data = reader->getData(path);
-    }
-
-    return data;
 }
 
 Reader* ReaderFactory::createReader(std::string extension) {


### PR DESCRIPTION
Removes a lot of unused functions and variables, also leaves image reading to the metadata reader, which was intended. The solution before was doing the same but in a weird way, the code was mostly copy pasted, but didn't actually create the image, the image creating was handled in CoverImage constructor. So I deleted all those methods as they are useless and rewrote CoverImage constructor.